### PR TITLE
🐞 fix: zjson.Unmarshal map data

### DIFF
--- a/zjson/get.go
+++ b/zjson/get.go
@@ -1983,21 +1983,15 @@ func assign(jsval *Res, val reflect.Value, fmap *fieldMaps) {
 		key := t.Key()
 		s := key.Kind() == reflect.String
 		if s {
-			kind := t.Elem().Kind()
-			switch kind {
-			case reflect.Interface:
-				val.Set(zreflect.ValueOf(jsval.Value()))
-			case reflect.Struct, reflect.Ptr:
-				v := reflect.MakeMap(t)
-				jsval.ForEach(func(key, value *Res) bool {
-					newval := reflect.New(t.Elem())
-					elem := newval.Elem()
-					assign(value, elem, fmap)
-					v.SetMapIndex(zreflect.ValueOf(key.Value()), elem)
-					return true
-				})
-				val.Set(v)
-			}
+			v := reflect.MakeMap(t)
+			jsval.ForEach(func(key, value *Res) bool {
+				newval := reflect.New(t.Elem())
+				elem := newval.Elem()
+				assign(value, elem, fmap)
+				v.SetMapIndex(zreflect.ValueOf(key.Value()), elem)
+				return true
+			})
+			val.Set(v)
 		}
 	case reflect.Interface:
 		val.Set(zreflect.ValueOf(jsval.Value()))

--- a/zjson/get_test.go
+++ b/zjson/get_test.go
@@ -246,6 +246,32 @@ func TestUnmarshal(t *testing.T) {
 	tt.Equal("n1", s.IDs[0].Gg.P[0].Name)
 }
 
+func TestUnmarshal2(t *testing.T) {
+	tt := zlsgo.NewTest(t)
+	json := `{"u1":[{"name":"HH","id":1},{"name":"HBB","id":2}]}`
+	var m map[string][]map[string]any
+	err := Unmarshal(json, &m)
+	tt.NoError(err)
+	tt.Logf("%+v", m)
+	tt.Equal("HH", m["u1"][0]["name"])
+	tt.Equal(2.0, m["u1"][1]["id"])
+
+	json = `{"u2":{"u3":1}}`
+	var m2 map[string]map[string]any
+	err = Unmarshal(json, &m2)
+	tt.NoError(err)
+	tt.Logf("%+v", m2)
+	tt.Equal(1.0, m2["u2"]["u3"])
+
+	json = `{"u4":2}`
+	var m3 map[string]int
+	err = Unmarshal(json, &m3)
+	tt.NoError(err)
+	tt.Logf("%+v", m3)
+	tt.Equal(2, m3["u4"])
+
+}
+
 func TestEditJson(t *testing.T) {
 	tt := zlsgo.NewTest(t)
 	j := Parse(demo)


### PR DESCRIPTION
`zjson.Unmarshal` 在处理如 `map[string][]any`  `map[string]int`  等value为非any、struct数据时，返回结果为空  

原因是此处对 value的类型做了case, 导致value非这三种类型的map均无法正常解析  

[:1982](https://github.com/sohaha/zlsgo/blob/master/zjson/get.go#L1982)
```go
	case reflect.Map:
		key := t.Key()
		s := key.Kind() == reflect.String
		if s {
			kind := t.Elem().Kind()
			switch kind {
			case reflect.Interface:
				val.Set(zreflect.ValueOf(jsval.Value()))
			case reflect.Struct, reflect.Ptr:
				v := reflect.MakeMap(t)
				jsval.ForEach(func(key, value *Res) bool {
					newval := reflect.New(t.Elem())
					elem := newval.Elem()
					assign(value, elem, fmap)
					v.SetMapIndex(zreflect.ValueOf(key.Value()), elem)
					return true
				})
				val.Set(v)
			}
		}

```

修复后将递归的调用`assign`方法，支持更多的map value类型